### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gets joke from icanhazdadjoke.com, prints it
 # Installation
 
 ```
-go get -u github.com/hakluke/hakjoke
+go install github.com/hakluke/hakjoke@latest
 ```
 
 # Usage


### PR DESCRIPTION
'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
